### PR TITLE
Copyediting: Replaced "products" with "experiences" on right copy

### DIFF
--- a/views/elements/content/right.md
+++ b/views/elements/content/right.md
@@ -2,14 +2,14 @@
 
 # **We design and ship outstanding digital products**.
 
-Whether you've got a napkin sketch or a scaled product, we'll help you launch simple, easy to use experiences from end-to-end. Our process is straightforward, proven, and — most importantly — fun. We pride ourselves on being kind, collaborative, technically skilled, and adaptive to change.
+Whether you've got a napkin sketch or a product with thousands of users, we'll help you launch simple, easy-to-use experiences from end to end. Our process is straightforward, proven, and — most importantly — fun. We pride ourselves on being collaborative, technically skilled, and adaptive to change.
 
 We work with clients to:
 ## Launch a new product
-You have a vision for a new product. We'll bring it into clear focus, then collaboratively design a seamless product.
+You have a vision for a new experience. We'll bring your vision to life through strategy and design.
 
 ## Iterate on an existing product
-You want to improve your current product. We’ll unpack the opportunity, shape it into a tangible outcome, then design it.
+Your digital experience is live, but you want to make it better. We’ll unpack your ideas, shape it into a tangible outcome, then design it.
 
 ## Augment your team
 You need an in-house product design team, or to add new minds to your existing team. We'll embed ourselves within your company to solve tough problems.


### PR DESCRIPTION
-  Replaced "products" with "experiences" on right copy, so that we only use it 3 times. 
- Took out "kind" in "We pride ourselves being X, Y, and Z." Keeping it to 3 items so it reads smooth.